### PR TITLE
Add filtering check in left-sidebar

### DIFF
--- a/packages/cli/src/components/left-sidebar.tsx
+++ b/packages/cli/src/components/left-sidebar.tsx
@@ -14,6 +14,9 @@ export default function LeftSidebar() {
   useKeyboard(key => {
     if (dialog.stack.length > 0) return
 
+    // Avoid triggering panes when filtering input is active
+    if (app.filtering) return;
+
     if (keybind.match("cycle_pane", key)) {
       switch (app.activePane) {
         case "containers":


### PR DESCRIPTION
This check exists in other useKeyboard calls but is missing in the left sidebar, which causes pane switching to trigger when entering a filtering slug in the containers pane.